### PR TITLE
Added Nextflow Tower CLI wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,22 @@ jobs:
           # Truncated..
 ```
 
+### `wait`
+
+**[Optional]** Set GitHub action to wait for pipeline completion 
+
+The default setting is for GitHub actions to               wait until a pipeline runs to completion. If you want GitHub actions to launch the workflow and then finish you can set the wait to false:
+
+```yaml
+jobs:
+  run-tower:
+    steps:
+      - uses: nf-core/tower-action@v2
+        with:
+          wait: false
+          # Truncated..
+```
+
 ## Outputs
 
 The action prints normal stdout info-level log messages to the actions console. However, it saves a verbose log file to `tower_action_*.log` (the `*` is a timestamp). We recommend using [`actions/upload-artifact`](https://github.com/actions/upload-artifact) in your GitHub Actions workflow as shown in the examples above, this will then expose this file as a download through the workflow summary page.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ jobs:
 
 **[Optional]** Set GitHub action to wait for pipeline completion 
 
-The default setting is for GitHub actions to               wait until a pipeline runs to completion. If you want GitHub actions to launch the workflow and then finish you can set the wait to false:
+The default setting is for GitHub actions to wait until a pipeline runs to completion. If you want GitHub actions to launch the workflow and then finish you can set the wait to false:
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ jobs:
           compute_env: ${{ secrets.TOWER_COMPUTE_ENV }}
           pipeline: YOUR_USERNAME/REPO
           revision: v1.2.1
+          run_name: ${{ github.job }}_${{ github.run_attempt }}
           workdir: ${{ secrets.AWS_S3_BUCKET }}/work/${{ github.sha }}
           # Set any custom pipeline params here - JSON object as a string
           parameters: |
@@ -157,6 +158,12 @@ These should be supplied as a valid JSON object, quoted as a string in your GitH
 **[Optional]** Nextflow config profiles.
 
 Pipeline config profiles to use. Should be comma separated without spaces.
+
+### `run_name`
+
+**[Optional]** Nextflow Tower run name
+
+Provide a name for the run in Nextflow Tower.
 
 ### `nextflow_config`
 

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
     required: false
   wait:
     description: Set GitHub action to wait for pipeline completion 
-    default: SUCCEEDED
+    default: false
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
   pre_run_script:
     description: Pre-run script before launch
     required: false
+  wait:
+    description: Set GitHub action to wait for pipeline completion 
+    default: SUCCEEDED
+    required: false
 
 runs:
   using: 'docker'
@@ -60,3 +64,4 @@ runs:
     CONFIG_PROFILES: ${{ inputs.profiles }}
     NEXTFLOW_CONFIG: ${{ inputs.nextflow_config }}
     PRE_RUN_SCRIPT: ${{ inputs.pre_run_script }}
+    WAIT: ${{ inputs.wait }}

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   profiles:
     description: Nextflow config profiles
     required: false
+  run_name:
+    description: Nextflow Tower Run Name
+    required: false
   nextflow_config:
     description: Nextflow config options
     required: false
@@ -62,6 +65,7 @@ runs:
     WORKDIR: ${{ inputs.workdir }}
     PARAMETERS: ${{ toJson(fromJson(inputs.parameters)) }}
     CONFIG_PROFILES: ${{ inputs.profiles }}
+    RUN_NAME: ${{ inputs.run_name }}
     NEXTFLOW_CONFIG: ${{ inputs.nextflow_config }}
     PRE_RUN_SCRIPT: ${{ inputs.pre_run_script }}
     WAIT: ${{ inputs.wait }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,7 @@ tw -v \
     ${TOWER_COMPUTE_ENV:+"--compute-env=$TOWER_COMPUTE_ENV"} \
     ${REVISION:+"--revision=$REVISION"} \
     ${CONFIG_PROFILES:+"--profile=$CONFIG_PROFILES"} \
-    ${RUN_NAME:+"--name=$RUN_NAME"} \
+    ${RUN_NAME:+"--name=${RUN_NAME/:/_}"} \
     ${PRE_RUN_SCRIPT:+"--pre-run=pre_run.sh"} \
     ${NEXTFLOW_CONFIG:+"--config=nextflow.config"} \
     ${WAIT:+"--wait=$WAIT"} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,6 +32,7 @@ tw -v \
     ${TOWER_COMPUTE_ENV:+"--compute-env=$TOWER_COMPUTE_ENV"} \
     ${REVISION:+"--revision=$REVISION"} \
     ${CONFIG_PROFILES:+"--profile=$CONFIG_PROFILES"} \
+    ${RUN_NAME:+"--name=$RUN_NAME"} \
     ${PRE_RUN_SCRIPT:+"--pre-run=pre_run.sh"} \
     ${NEXTFLOW_CONFIG:+"--config=nextflow.config"} \
     ${WAIT:+"--wait=$WAIT"} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,9 @@ echo -e "$PRE_RUN_SCRIPT" > pre_run.sh
 # Print the nextflow config  to a file
 echo -e "$NEXTFLOW_CONFIG" > nextflow.config
 
+# If wait is set to false then unset wait to disable waiting
+if [ "$WAIT" = false ]; then unset WAIT; fi
+
 # Launch the pipeline
 tw -v \
     launch \
@@ -31,6 +34,7 @@ tw -v \
     ${CONFIG_PROFILES:+"--profile=$CONFIG_PROFILES"} \
     ${PRE_RUN_SCRIPT:+"--pre-run=pre_run.sh"} \
     ${NEXTFLOW_CONFIG:+"--config=nextflow.config"} \
+    ${WAIT:+"--wait=$WAIT"} \
     2>> $LOG_FN | tee -a $LOG_FN
 
 # Strip secrets from the log file


### PR DESCRIPTION
_Recreating https://github.com/nf-core/tower-action/pull/18 by [k-florek](https://github.com/k-florek) on the new repo. Original PR comment:_

---

I added the tower CLI wait functionality to the action as the default. You can set the wait to false to disable. This should address everything that was discussed in issue #13.

---

I also added run name as a parameter so that a unique name could be specified to make the github action run standout from other runs in tower.