### PR TITLE
Set pipefail for entrypoint.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # seqeralabs/action-tower-launch: Changelog
 
+## [ dev ]
+
+Action will now fail if pipeline submission fails.
+
 ## [[Version 1.0](https://github.com/seqeralabs/action-tower-launch/releases/tag/1.0)] - 2023-03-28
 
 Repository moved to [seqeralabs/action-tower-launch](https://github.com/seqeralabs/action-tower-launch).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [ dev ]
 
-Action will now fail if pipeline submission fails.
+- Action will now fail if pipeline submission fails ([#2](https://github.com/seqeralabs/action-tower-launch/pull/2))
 
 ## [[Version 1.0](https://github.com/seqeralabs/action-tower-launch/releases/tag/1.0)] - 2023-03-28
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -euxo pipefail
 
 # Use `tee` to print just stdout to the console but save stdout + stderr to a file
 LOG_FN="tower_action_"$(date +'%Y_%m_%d-%H_%M')".log"


### PR DESCRIPTION
`set -euxo pipefail` means the pipeline fails appropriately when a the action fails to launch a run.