### PR TITLE
Add outputs to GHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine
 ARG TOWER_CLI_VERSION="0.7.3"
 
 # Install Tower CLI
-RUN apk add --no-cache curl ca-certificates
+RUN apk add --no-cache curl ca-certificates jq
 RUN curl -L https://github.com/seqeralabs/tower-cli/releases/download/v${TOWER_CLI_VERSION}/tw-${TOWER_CLI_VERSION}-linux-x86_64 > tw
 RUN chmod +x ./tw
 RUN mv tw /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine
 ARG TOWER_CLI_VERSION="0.7.3"
 
 # Install Tower CLI
-RUN apk add --no-cache curl ca-certificates jq
+RUN apk add --no-cache curl ca-certificates jq uuidgen
 RUN curl -L https://github.com/seqeralabs/tower-cli/releases/download/v${TOWER_CLI_VERSION}/tw-${TOWER_CLI_VERSION}-linux-x86_64 > tw
 RUN chmod +x ./tw
 RUN mv tw /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -197,13 +197,13 @@ jobs:
     steps:
       - uses: seqeralabs/action-tower-launch@v1
         with:
-          pre_run_script: 'export NXF_VER=21.10.3'
+          pre_run_script: "export NXF_VER=21.10.3"
           # Truncated..
 ```
 
 ### `wait`
 
-**[Optional]** Set GitHub action to wait for pipeline completion 
+**[Optional]** Set GitHub action to wait for pipeline completion
 
 The default setting is for GitHub actions to wait until a pipeline runs to completion. If you want GitHub actions to launch the workflow and then finish you can set the wait to false:
 
@@ -218,6 +218,17 @@ jobs:
 ```
 
 ## Outputs
+
+The action writes the output variable `json` which is a JSON string of metadata created by the Tower API. It looks like this:
+
+```
+{
+  "workflowId" : "7f061c344df044",
+  "workflowUrl" : "https://tower.nf/orgs/myorg/workspaces/myworkspace/watch/7f061c344df044",
+  "workspaceId" : 123456789,
+  "workspaceRef" : "[myorg / myworkspace]"
+}
+```
 
 The action prints normal stdout info-level log messages to the actions console. However, it saves a verbose log file to `tower_action_*.log` (the `*` is a timestamp). We recommend using [`actions/upload-artifact`](https://github.com/actions/upload-artifact) in your GitHub Actions workflow as shown in the examples above, this will then expose this file as a download through the workflow summary page.
 

--- a/README.md
+++ b/README.md
@@ -291,9 +291,8 @@ jobs:
           # Install TW CLI
           set -euxo pipefail
           wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.7.3/tw-0.7.3-linux-x86_64
-          mv tw-* tw
-          chmod +x tw
-          sudo mv tw /usr/local/bin/
+          sudo mv tw-* /usr/local/bin/tw
+          chmod +x /usr/local/bin/tw
           # Use variables with ${{ needs.id.outputs.variable }} syntax
           tw -o json runs view -w ${{ needs.run-tower.outputs.workspace_id }} -i ${{ needs.run-tower.outputs.workflow_id }}
 ```

--- a/README.md
+++ b/README.md
@@ -248,9 +248,27 @@ inputs:
 # Becomes an object which can be used, e.g. ${{ inputs.json.workflowId }}
 ```
 
-### Logs
+### Files
 
-The action prints normal stdout info-level log messages to the actions console. However, it saves a verbose log file to `tower_action_*.log` (the `*` is a timestamp). We recommend using [`actions/upload-artifact`](https://github.com/actions/upload-artifact) in your GitHub Actions workflow as shown in the examples above, this will then expose this file as a download through the workflow summary page.
+The action prints normal stdout info-level log messages to the actions console. However, it also saves a verbose log file and an output JSON of job details as a file. We recommend using [`actions/upload-artifact`](https://github.com/actions/upload-artifact) in your GitHub Actions workflow as shown in the examples above, this will then expose this file to be used in subsequent jobs and as a download through the workflow summary page.
+
+The output log file is saved as `tower_action_$(timestamp).log` and can be captured using `actions/upload-artifact using the following settings:
+
+```
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Tower debug log file
+          path: tower_action_*.log
+```
+
+The action writes a JSON file which has the same format as the `outputs.json` used above. This is wrtten to a file called `tower_action_$(uuidgen).json`. It can be captured in a similar manner:
+
+```
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Tower output JSON file
+          path: tower_action_*.json
+```
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ jobs:
 
 ## Outputs
 
+### Output variables
+
 The action creates the output variable `json` which is a JSON string of metadata created by the Tower API. It looks like this:
 
 ```
@@ -238,6 +240,8 @@ inputs:
   json: ${{ fromJSON( steps.tower-action.outputs.json) }}
 # Becomes an object which can be used, e.g. ${{ inputs.json.workflowId }}
 ```
+
+### Logs
 
 The action prints normal stdout info-level log messages to the actions console. However, it saves a verbose log file to `tower_action_*.log` (the `*` is a timestamp). We recommend using [`actions/upload-artifact`](https://github.com/actions/upload-artifact) in your GitHub Actions workflow as shown in the examples above, this will then expose this file as a download through the workflow summary page.
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ jobs:
 
 ### Output variables
 
-The action creates the output variable `json` which is a JSON string of metadata created by the Tower API. It looks like this:
+The action creates the output variable `json` which is a JSON string of metadata created by the Tower API. It looks like this and can be parsed using the built in `fromJSON()` method.
 
 ```
 {
@@ -238,15 +238,6 @@ In addition, each variable is available as a separate output available under the
 - `workflowUrl`
 - `workspaceId`
 - `workspaceRef`
-
-This can be used in subsequent steps by parsing the JSON string:
-
-```
-# TODO: Make this better
-inputs:
-  json: ${{ fromJSON( steps.tower-action.outputs.json) }}
-# Becomes an object which can be used, e.g. ${{ inputs.json.workflowId }}
-```
 
 ### Files
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ jobs:
 
 ## Outputs
 
-The action writes the output variable `json` which is a JSON string of metadata created by the Tower API. It looks like this:
+The action creates the output variable `json` which is a JSON string of metadata created by the Tower API. It looks like this:
 
 ```
 {
@@ -228,6 +228,15 @@ The action writes the output variable `json` which is a JSON string of metadata 
   "workspaceId" : 123456789,
   "workspaceRef" : "[myorg / myworkspace]"
 }
+```
+
+This can be used in subsequent steps by parsing the JSON string:
+
+```
+# TODO: Make this better
+inputs:
+  json: ${{ fromJSON( steps.tower-action.outputs.json) }}
+# Becomes an object which can be used, e.g. ${{ inputs.json.workflowId }}
 ```
 
 The action prints normal stdout info-level log messages to the actions console. However, it saves a verbose log file to `tower_action_*.log` (the `*` is a timestamp). We recommend using [`actions/upload-artifact`](https://github.com/actions/upload-artifact) in your GitHub Actions workflow as shown in the examples above, this will then expose this file as a download through the workflow summary page.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ jobs:
             }
           # List of pipeline config profiles to use - comma separated list as a string
           profiles: test,aws_tower
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ needs.getdate.outputs.date }}_run_json
+          path: tower_action_*.json
+
       - uses: actions/upload-artifact@v3
         with:
           name: Tower debug log file
@@ -266,13 +272,17 @@ jobs:
           name: Tower debug log file
           path: tower_action_*.log
 
-      # Echo variables to console
-      - name: Echo variables
-        run: |
-          echo "Worfklow ID: ${{ steps.run.outputs.workflowId }}"
-          echo "Workflow URL: ${{ steps.run.outputs.workflowUrl }}"
-          echo "Workspace ID: ${{ steps.run.outputs.workspaceId }}"
-          echo "Workspace Reference: ${{ steps.run.outputs.workspaceRef }}"
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            Pipeline launched, monitor progress [here](${{ steps.runs.outputs.workflowUrl }})
+            Details:
+              - Workflow ID: ${{ steps.runs.outputs.workflowId }}
+              - Workspace: ${{ steps.runs.outputs.WorkspaceRef }} 
+              - Workspace ID: ${{ steps.runs.outputs.workspaceId }}
+              - Workflow URL: ${{ steps.runs.outputs.workflowUrl }}
+          comment_tag: towerrun
 
       # Capture JSON and save as artifact
       - uses: actions/upload-artifact@v3
@@ -280,6 +290,13 @@ jobs:
         with:
           name: ${{ needs.getdate.outputs.date }}_run_json
           path: tower_action_*.json
+
+      # Capture logs
+      - uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: Tower debug log file
+          path: tower_action_*.log
 
   # We install the Tower CLI and use the variables to get the details of the pipeline run.
   get_details:

--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ jobs:
           mv tw-* tw
           chmod +x tw
           sudo mv tw /usr/local/bin/
-          tw -o json runs view -w ${{ needs.run-tower.workspace_id }} -i ${{ needs.run-tower.workflow_id }}
+          # Use variables with ${{ needs.id.outputs.variable }} syntax
+          tw -o json runs view -w ${{ needs.run-tower.outputs.workspace_id }} -i ${{ needs.run-tower.outputs.workflow_id }}
 ```
 
 ### Files

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ From the example above, we can now extend it to use the output variables in down
 
 ```yaml
 on:
+  pull_request:
   push:
     branches: [dev]
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,6 @@ jobs:
       - name: Get run details
         run: |
           # Install TW CLI
-          set -euxo pipefail
           wget -L https://github.com/seqeralabs/tower-cli/releases/download/v0.7.3/tw-0.7.3-linux-x86_64
           sudo mv tw-* /usr/local/bin/tw
           chmod +x /usr/local/bin/tw

--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ The action creates the output variable `json` which is a JSON string of metadata
 }
 ```
 
+In addition, each variable is available as a separate output available under the following IDs:
+
+- `workflowId`
+- `workflowUrl`
+- `workspaceId`
+- `workspaceRef`
+
 This can be used in subsequent steps by parsing the JSON string:
 
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,8 @@ author: Phil Ewels
 description: Launch a workflow using Nextflow Tower (https://tower.nf)
 
 branding:
-  icon: 'play'
-  color: 'purple'
+  icon: "play"
+  color: "purple"
 
 inputs:
   access_token:
@@ -48,12 +48,12 @@ inputs:
     description: Pre-run script before launch
     required: false
   wait:
-    description: Set GitHub action to wait for pipeline completion 
+    description: Set GitHub action to wait for pipeline completion
     default: false
     required: false
 
 runs:
-  using: 'docker'
+  using: "docker"
   image: Dockerfile
   env:
     TOWER_WORKSPACE_ID: ${{ inputs.workspace_id }}
@@ -69,3 +69,6 @@ runs:
     NEXTFLOW_CONFIG: ${{ inputs.nextflow_config }}
     PRE_RUN_SCRIPT: ${{ inputs.pre_run_script }}
     WAIT: ${{ inputs.wait }}
+  outputs:
+    json:
+      description: JSON from tw launch with workflowID, workflowUrl, workspaceId, workspaceRef

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,14 @@ inputs:
 outputs:
   json:
     description: JSON from tw launch with workflowID, workflowUrl, workspaceId, workspaceRef
+  workflowId:
+    description: Unique ID of the pipeline run in Nextflow Tower.
+  workflowUrl:
+    description: URL to pipeline run in Nextflow Tower.
+  workspaceId:
+    description: Unique ID of workspace in Nextflow Tower in which the pipeline is running.
+  workspaceRef:
+    description: Human readable format of workspace in Nextflow tower in format '[ organisation / workspace ]'.
 
 runs:
   using: "docker"

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,10 @@ inputs:
     default: false
     required: false
 
+outputs:
+  json:
+    description: JSON from tw launch with workflowID, workflowUrl, workspaceId, workspaceRef
+
 runs:
   using: "docker"
   image: Dockerfile
@@ -69,7 +73,3 @@ runs:
     NEXTFLOW_CONFIG: ${{ inputs.nextflow_config }}
     PRE_RUN_SCRIPT: ${{ inputs.pre_run_script }}
     WAIT: ${{ inputs.wait }}
-
-outputs:
-  json:
-    description: JSON from tw launch with workflowID, workflowUrl, workspaceId, workspaceRef

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,7 @@ runs:
     NEXTFLOW_CONFIG: ${{ inputs.nextflow_config }}
     PRE_RUN_SCRIPT: ${{ inputs.pre_run_script }}
     WAIT: ${{ inputs.wait }}
-  outputs:
-    json:
-      description: JSON from tw launch with workflowID, workflowUrl, workspaceId, workspaceRef
+
+outputs:
+  json:
+    description: JSON from tw launch with workflowID, workflowUrl, workspaceId, workspaceRef

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,8 +37,8 @@ export OUT=$(tw -o json -v \
     ${PRE_RUN_SCRIPT:+"--pre-run=pre_run.sh"} \
     ${NEXTFLOW_CONFIG:+"--config=nextflow.config"} \
     ${WAIT:+"--wait=$WAIT"} \
-    2>> $LOG_FN | tee -a $LOG_FN)
+    2>> $LOG_FN | tee -a $LOG_FN | jq -rc)
 
 # Strip secrets from the log file
 sed -i "s/$TOWER_ACCESS_TOKEN/xxxxxx/" $LOG_FN
-echo "json=$OUT" >> $GITHUB_OUTPUT
+echo "json=\"$OUT\"" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,8 +41,8 @@ export OUT=$(tw -o json -v \
 
 # Strip secrets from the log file
 sed -i "s/$TOWER_ACCESS_TOKEN/xxxxxx/" $LOG_FN
-echo "workflowId=$(echo $OUT | jq '.workflowId')" >> $GITHUB_OUTPUT
-echo "workflowUrl=$(echo $OUT | jq '.workflowUrl')" >> $GITHUB_OUTPUT
-echo "workspaceId=$(echo $OUT | jq '.workspaceId')" >> $GITHUB_OUTPUT
-echo "workspaceRef=$(echo $OUT | jq '.workspaceRef')" >> $GITHUB_OUTPUT
-echo "json=$(echo $OUT | jq -c) >> $GITHUB_OUTPUT
+echo workflowId=$(echo $OUT | jq '.workflowId') >> $GITHUB_OUTPUT
+echo workflowUrl=$(echo $OUT | jq '.workflowUrl') >> $GITHUB_OUTPUT
+echo workspaceId=$(echo $OUT | jq '.workspaceId') >> $GITHUB_OUTPUT
+echo workspaceRef=$(echo $OUT | jq '.workspaceRef') >> $GITHUB_OUTPUT
+echo json=$OUT >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ echo -e "$NEXTFLOW_CONFIG" > nextflow.config
 if [ "$WAIT" = false ]; then unset WAIT; fi
 
 # Launch the pipeline
-tw -v \
+export OUT=$(tw -v \
     launch \
     $PIPELINE \
     --params-file=params.json \
@@ -37,7 +37,8 @@ tw -v \
     ${PRE_RUN_SCRIPT:+"--pre-run=pre_run.sh"} \
     ${NEXTFLOW_CONFIG:+"--config=nextflow.config"} \
     ${WAIT:+"--wait=$WAIT"} \
-    2>> $LOG_FN | tee -a $LOG_FN
+    2>> $LOG_FN | tee -a $LOG_FN)
 
 # Strip secrets from the log file
 sed -i "s/$TOWER_ACCESS_TOKEN/xxxxxx/" $LOG_FN
+echo "json=$OUT" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,4 +45,4 @@ echo "workflowId=$(echo $OUT | jq '.workflowId')" >> $GITHUB_OUTPUT
 echo "workflowUrl=$(echo $OUT | jq '.workflowUrl')" >> $GITHUB_OUTPUT
 echo "workspaceId=$(echo $OUT | jq '.workspaceId')" >> $GITHUB_OUTPUT
 echo "workspaceRef=$(echo $OUT | jq '.workspaceRef')" >> $GITHUB_OUTPUT
-echo "json=$(echo $OUT | jq -Rc) >> $GITHUB_OUTPUT
+echo "json=$(echo $OUT | jq -c) >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,4 +41,4 @@ export OUT=$(tw -o json -v \
 
 # Strip secrets from the log file
 sed -i "s/$TOWER_ACCESS_TOKEN/xxxxxx/" $LOG_FN
-echo "json=\"$OUT\"" >> $GITHUB_OUTPUT
+echo "json=$OUT" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,7 @@ export OUT=$(tw -o json -v \
     ${PRE_RUN_SCRIPT:+"--pre-run=pre_run.sh"} \
     ${NEXTFLOW_CONFIG:+"--config=nextflow.config"} \
     ${WAIT:+"--wait=$WAIT"} \
-    2>> $LOG_FN | tee -a $LOG_FN)
+    2>> $LOG_FN | tee -a $LOG_FN | jq -rc)
 
 # Strip secrets from the log file
 sed -i "s/$TOWER_ACCESS_TOKEN/xxxxxx/" $LOG_FN

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,8 @@
 set -euxo pipefail
 
 # Use `tee` to print just stdout to the console but save stdout + stderr to a file
-LOG_FN="tower_action_"$(date +'%Y_%m_%d-%H_%M')".log"
+LOG_FN="tower_action_"$(date +'%Y_%m_%d-%H_%M')"_.log"
+LOG_JSON="tower_action_"$(uuidgen)".json"
 
 # Manual curl of service-info
 curl https://api.tower.nf/service-info >> $LOG_FN
@@ -39,10 +40,14 @@ export OUT=$(tw -o json -v \
     ${WAIT:+"--wait=$WAIT"} \
     2>> $LOG_FN | tee -a $LOG_FN | jq -rc)
 
-# Strip secrets from the log file
-sed -i "s/$TOWER_ACCESS_TOKEN/xxxxxx/" $LOG_FN
 echo workflowId=$(echo $OUT | jq '.workflowId') >> $GITHUB_OUTPUT
 echo workflowUrl=$(echo $OUT | jq '.workflowUrl') >> $GITHUB_OUTPUT
 echo workspaceId=$(echo $OUT | jq '.workspaceId') >> $GITHUB_OUTPUT
 echo workspaceRef=$(echo $OUT | jq '.workspaceRef') >> $GITHUB_OUTPUT
 echo json=$OUT >> $GITHUB_OUTPUT
+
+# Strip secrets from the log file
+sed -i "s/$TOWER_ACCESS_TOKEN/xxxxxx/" $LOG_FN
+
+# Create output json file
+echo $OUT > $LOG_JSON

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,8 +37,12 @@ export OUT=$(tw -o json -v \
     ${PRE_RUN_SCRIPT:+"--pre-run=pre_run.sh"} \
     ${NEXTFLOW_CONFIG:+"--config=nextflow.config"} \
     ${WAIT:+"--wait=$WAIT"} \
-    2>> $LOG_FN | tee -a $LOG_FN | jq -rc)
+    2>> $LOG_FN | tee -a $LOG_FN)
 
 # Strip secrets from the log file
 sed -i "s/$TOWER_ACCESS_TOKEN/xxxxxx/" $LOG_FN
-echo "json=$OUT" >> $GITHUB_OUTPUT
+echo "workflowId=$(echo $OUT | jq '.workflowId')" >> $GITHUB_OUTPUT
+echo "workflowUrl=$(echo $OUT | jq '.workflowUrl')" >> $GITHUB_OUTPUT
+echo "workspaceId=$(echo $OUT | jq '.workspaceId')" >> $GITHUB_OUTPUT
+echo "workspaceRef=$(echo $OUT | jq '.workspaceRef')" >> $GITHUB_OUTPUT
+echo "json=$(echo $OUT | jq -Rc) >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ echo -e "$NEXTFLOW_CONFIG" > nextflow.config
 if [ "$WAIT" = false ]; then unset WAIT; fi
 
 # Launch the pipeline
-export OUT=$(tw -v \
+export OUT=$(tw -o json -v \
     launch \
     $PIPELINE \
     --params-file=params.json \


### PR DESCRIPTION
This adds some outputs for the action to capture.

- The `workflowId`, `workflowUrl`, `workspaceId` and `workspaceRef` are captured as outputs
- A complete JSON string of the above is captured for use as a complete object
- The JSON is created as an output file which can be captured as an artefact.