### PR TITLE
Output quotes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,14 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
-            Pipeline launched, monitor progress [here](${{ steps.runs.outputs.workflowUrl }})
+            ### 🚀 Pipeline launched, monitor progress [here](${{ steps.runs.outputs.workflowUrl }}).
 
-            Details:
-             - Workflow ID: ${{ steps.runs.outputs.workflowId }}
-             - Workspace: ${{ steps.runs.outputs.workspaceRef }} 
-             - Workspace ID: ${{ steps.runs.outputs.workspaceId }}
-             - Workflow URL: ${{ steps.runs.outputs.workflowUrl }}
+            | Name | Info |
+            |------|------|
+            | 🔨 Workflow ID | `${{ steps.runs.outputs.workflowId }}` |
+            | 🏠 Workspace | `${{ steps.runs.outputs.workspaceRef }}` |
+            | 🗂️ Workspace ID | `${{ steps.runs.outputs.workspaceId }}` |
+            | 😎 Workflow URL | ${{ steps.runs.outputs.workflowUrl }} |
           comment_tag: towerrun
 
       - uses: actions/upload-artifact@v3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,10 +48,10 @@ export OUT=$(tw -o json -v \
     2>> $LOG_FN | tee -a $LOG_FN | base64 -w 0)
 
 # Base64 decode and extract specific value for output
-export workflowId=$(echo $OUT | base64 -d | jq '.workflowId')
-export workflowUrl=$(echo $OUT | base64 -d | jq '.workflowUrl')
-export workspaceId=$(echo $OUT | base64 -d | jq '.workspaceId')
-export workspaceRef=$(echo $OUT | base64 -d | jq '.workspaceRef')
+export workflowId=$(echo $OUT | base64 -d | jq -r '.workflowId')
+export workflowUrl=$(echo $OUT | base64 -d | jq -r '.workflowUrl')
+export workspaceId=$(echo $OUT | base64 -d | jq -r '.workspaceId')
+export workspaceRef=$(echo $OUT | base64 -d | jq -r '.workspaceRef')
 
 # Hide from the logs for Github Actions. Not crucial but good practice.
 echo "::add-mask::$OUT"


### PR DESCRIPTION
Noticed that the workspace ID and names were quoted in [this comment](https://github.com/seqeralabs/action-tower-launch/pull/4#issuecomment-1527376317). Figured that might break stuff for people.

* `jq` with `-r` flag, to avoid quotes in strings
* Fancier CI comment markdown