### PR TITLE
Fix workflow fails if job is not submitted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,24 @@ jobs:
             | 😎 Workflow URL | ${{ steps.runs.outputs.workflowUrl }} |
           comment_tag: towerrun
         if: github.event_name == 'pull_request'
+      
+      - uses: ./
+        id: runfails
+        continue-on-error: true
+        with:
+          pipeline: no_pipeline_exists
+          revision: master
+          workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
+          access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
+          compute_env: ${{ secrets.TOWER_COMPUTE_ENV }}
+          run_name: ${{ github.job }}_${{ github.sha }}
+          workdir: ${{ secrets.AWS_S3_BUCKET }}/work/${{ github.sha }}
+
+      - name: Check Failure
+        if: steps.runfails.outcome == 'failure'
+        run: |
+          echo "Pipeline submission was not caught"
+          exit 1      
 
       - uses: actions/upload-artifact@v3
         with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,8 @@ if [ "$WAIT" = false ]; then unset WAIT; fi
 
 # Launch the pipeline
 # We use capture the JSON as variable $OUT. We encode it as base64 to get around Github secrets filters but we still mask it anyway to make sure the details don't leak.
-export OUT=$(tw -o json -v \
+export OUT
+OUT=$(tw -o json -v \
     launch \
     $PIPELINE \
     --params-file=params.json \


### PR DESCRIPTION
Changes:
 - 'export' was succeeding, so the workflow passed. Now separates to two steps which should fail properly.
 - Add failing test