### PR TITLE
Update tw-cli to 0.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             | 😎 Workflow URL | ${{ steps.runs.outputs.workflowUrl }} |
           comment_tag: towerrun
         if: github.event_name == 'pull_request'
-      
+
       - uses: ./
         id: runfails
         continue-on-error: true
@@ -65,11 +65,13 @@ jobs:
           exit 1
 
       - uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
           name: ${{ github.job }}_run_json
           path: tower_action_*.json
 
       - uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
           name: Tower debug log file
           path: tower_action_*.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           exit 1
 
       - uses: actions/upload-artifact@v3
-        if: success() || failure()
+        if: success()
         with:
           name: ${{ github.job }}_run_json
           path: tower_action_*.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           workdir: ${{ secrets.AWS_S3_BUCKET }}/work/${{ github.sha }}
 
       - name: Comment PR
+        if: github.event_name == 'pull_request'
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
@@ -44,11 +45,10 @@ jobs:
             | 🗂️ Workspace ID | `${{ steps.runs.outputs.workspaceId }}` |
             | 😎 Workflow URL | ${{ steps.runs.outputs.workflowUrl }} |
           comment_tag: towerrun
-        if: github.event_name == 'pull_request'
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v2
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         with:
           message: |
             ### :x: Pipeline launch failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,16 @@ jobs:
           comment_tag: towerrun
         if: github.event_name == 'pull_request'
 
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        if: failure()
+        with:
+          message: |
+            ### :x: Pipeline launch failed
+
+            The pipeline launch failed. Check the logs uploaded as an artifact for more information.
+          comment_tag: towerrun
+
       - uses: ./
         id: runfails
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## [ dev ]
 
+- Update Tower CLI to v0.8.0 ([#11](https://github.com/seqeralabs/action-tower-launch/pull/11))
+- Fix: Output JSON file not base64 encoded
+- Fix: Additional underscore from log removed
+- Feature: Additional comment to PR if launching fails
+
+## [ 0.7.3 ]
+
 - Feature: Action will now fail if pipeline submission fails ([#2](https://github.com/seqeralabs/action-tower-launch/pull/2))
+
+## [ 0.7.2 ]
+
 - Feature: Add outputs to action [#3](https://github.com/seqeralabs/action-tower-launch/pull/3)
 - CI/CD: Add default test run to confirm correct running [#4](https://github.com/seqeralabs/action-tower-launch/pull/4)
 - Fix: Remove quotes from output strings [#5](https://github.com/seqeralabs/action-tower-launch/pull/5)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ FROM alpine
 ARG TOWER_CLI_VERSION="0.8.0"
 
 # Install Tower CLI
-RUN apk add --no-cache curl ca-certificates jq uuidgen
-RUN curl -L https://github.com/seqeralabs/tower-cli/releases/download/v${TOWER_CLI_VERSION}/tw-${TOWER_CLI_VERSION}-linux-x86_64 > tw
-RUN chmod +x ./tw
-RUN mv tw /usr/local/bin/
+RUN apk add --no-cache curl ca-certificates jq uuidgen \
+    && curl -L https://github.com/seqeralabs/tower-cli/releases/download/v${TOWER_CLI_VERSION}/tw-linux-x86_64 > tw \
+    && chmod +x ./tw \
+    && mv tw /usr/local/bin/ \
+    && tw --version
 
 # Make action script available
 ADD *.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-ARG TOWER_CLI_VERSION="0.7.3"
+ARG TOWER_CLI_VERSION="0.8.0"
 
 # Install Tower CLI
 RUN apk add --no-cache curl ca-certificates jq uuidgen

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,3 +72,5 @@ sed -i "s/$TOWER_ACCESS_TOKEN/xxxxxx/" $LOG_FN
 
 # Create output json file
 echo $OUT > $LOG_JSON
+
+cat $LOG_FN

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,7 @@ echo "::add-mask::$TOWER_API_ENDPOINT"
 echo "::add-mask::$TOWER_ACCESS_TOKEN"
 echo "::add-mask::$TOWER_COMPUTE_ENV"
 
-# Use `tee` to print just stdout to the console but save stdout + stderr to a file
-LOG_FN="tower_action_"$(date +'%Y_%m_%d-%H_%M')"_.log"
+LOG_FN=tower_action_$(date +'%Y_%m_%d-%H_%M').log
 LOG_JSON="tower_action_"$(uuidgen)".json"
 
 # Manual curl of service-info

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,6 +70,6 @@ echo "json='$(echo $OUT | base64 -d | jq -rc)'"  >> $GITHUB_OUTPUT
 sed -i "s/$TOWER_ACCESS_TOKEN/xxxxxx/" $LOG_FN
 
 # Create output json file
-echo $OUT > $LOG_JSON
+echo $OUT | base64 -d > $LOG_JSON
 
 cat $LOG_FN


### PR DESCRIPTION
- Update Tower CLI to v0.8.0
- Fix: Output JSON file not base64 encoded
- Fix: Additional underscore from log removed
- Feature: Additional comment to PR if launching fails