### PR TITLE
Default revision is no longer github.sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
         # Use repository secrets for sensitive fields
         with:
           pipeline: hello_world
-          revision: master
           workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
           compute_env: ${{ secrets.TOWER_COMPUTE_ENV }}
@@ -61,7 +60,6 @@ jobs:
         continue-on-error: true
         with:
           pipeline: no_pipeline_exists
-          revision: master
           workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
           compute_env: ${{ secrets.TOWER_COMPUTE_ENV }}

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,6 @@ inputs:
     required: false
   revision:
     description: Pipeline revision (release / branch)
-    default: ${{ github.sha }}
     required: false
   workdir:
     description: Nextflow work directory

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -euo pipefail
 
-echo $REVISION
-
 # Mask certain variables from Github logs
 echo "::add-mask::$TOWER_WORKSPACE_ID"
 echo "::add-mask::$TOWER_API_ENDPOINT"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -euo pipefail
 
+echo $REVISION
+
 # Mask certain variables from Github logs
 echo "::add-mask::$TOWER_WORKSPACE_ID"
 echo "::add-mask::$TOWER_API_ENDPOINT"


### PR DESCRIPTION
See #13 

Setting the default revision to github.sha caused the pipeline launch to fail because it was using an SHA from an unrelated commit (e.g. from a different repository). Furthermore, it was risky because it can cause pipelines to use the SHA revision instead of the default (e.g. a user may want to launch the configured version on Tower).

A nice idea, but let users set their own parameters.