### PR TITLE
Update Tower CLI to v0.21.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-ARG TOWER_CLI_VERSION="0.12.0"
+ARG TOWER_CLI_VERSION="0.21.0"
 
 # Install Tower CLI
 RUN apk add --no-cache curl ca-certificates jq uuidgen \


### PR DESCRIPTION
Updates Tower CLI to v0.21.0 which includes bug fixes and improvements.